### PR TITLE
Add operations to fetch and parse pages, then generate a basic sitemap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 An asyncio-based crawler.
 
-## Basics branch
+## Branches
+
+### Basics branch
 
 1. Package layout - https://docs.python-guide.org/writing/structure/
 2. Async testing with pytest
@@ -10,3 +12,9 @@ An asyncio-based crawler.
 
 Plus additions to requirements.txt, etc.
 
+### Crawl operations
+
+1. Use aiohttp client to fetch pages
+2. Wrap stdlib html.parser.HTMLParser to parse pages
+3. Change crawl function to fetch and parse a page, not just sleep, and output a
+   very basic sitemap based on YAML serialization

--- a/acrawler.py
+++ b/acrawler.py
@@ -1,13 +1,79 @@
 import asyncio
+import collections
 import sys
+from dataclasses import dataclass
+from html.parser import HTMLParser
+
+import aiohttp
+from ruamel.yaml import YAML
+
+
+class CollectorHTMLParser(HTMLParser):
+    """Subclasses `HTMLParser` to call `collector` on each matching tag in `collect_tags`"""
+    def __init__(self, collect_tags, collector):
+        self.collect_tags = collect_tags
+        self.collector = collector
+        super().__init__()
+
+    def handle_starttag(self, tag, attrs):
+        if tag in self.collect_tags:
+            self.collector((tag, attrs))
+
+
+@dataclass
+class Tag:
+    name: str
+    attrs: dict
+    
+
+class TagParser:
+    """For each chunk passed to `consume`, yields the corresponding tags.
+
+    This design allows us to fan out from a chunk of HTML text that has been
+    fetched to the corresponding tags, possibly none.
+
+    Uses an inheritance by composition design on the underlying HTMLParser
+    class."""
+    def __init__(self, collect_tags):
+        self.queue = collections.deque()
+        self.html_parser = CollectorHTMLParser(collect_tags, self.queue.append)
+
+    def consume(self, chunk):
+        self.html_parser.feed(chunk)
+        while self.queue:
+            tag, attrs = self.queue.popleft()
+            yield Tag(tag, dict(attrs))
+
+
+async def fetch(session, url, chunk_size=8192):
+    """Given `session`, yields string chunks from the `url`"""
+    async with session.get(url) as response:
+        while True:
+            chunk = await response.content.read(chunk_size)
+            if not chunk:
+                break
+            else:
+                # HTMLParser wants str, not bytes, so coerce accordingly,
+                # assuming UTF-8
+                # FIXME: doublecheck text encoding support
+                yield str(chunk)
 
 
 async def crawl(site_url):
-    print(f"Crawling {site_url}...")
-    await asyncio.sleep(1)
-    print("Done.")
+    """Given `site_url`, just crawls that page and writes to stdout a sitemap"""
 
+    tag_parser = TagParser({"a", "img"})
+    yaml = YAML()
+    yaml.register_class(Tag)  # TODO: consider nondefault serialization
+    async with aiohttp.ClientSession() as session:
+        async for chunk in fetch(session, site_url):
+            for tag in tag_parser.consume(chunk):
+                if tag.name == "a":
+                    # NOTE: outputing a list takes advantage of YAML's
+                    # serialization for lists, which is both concatable and
+                    # tailable
+                    yaml.dump([tag], sys.stdout)
+                
 
 if __name__ == "__main__":  # pragma: no cover
     asyncio.run(crawl(sys.argv[1]))
-

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+filterwarnings =
+    ignore::DeprecationWarning:aiohttp.*:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,6 @@
+aiohttp[speedups]   # use for asyncio HTTP client
+ruamel.yaml         # YAML 1.2 serializer/deserializer
+
+# testing support
 pytest-asyncio
 pytest-cov

--- a/test_acrawler.py
+++ b/test_acrawler.py
@@ -2,9 +2,38 @@ import pytest
 import acrawler
 
 
+# Based on the page from https://example.com
+example_html = """
+<!doctype html>
+<html>
+<head>
+    <title>Example Domain</title>
+</head>
+<body>
+<div>
+    <h1>Example Domain</h1>
+    <p><a href="https://www.iana.org/domains/example">More information...</a></p>
+</div>
+</body>
+</html>
+"""
+
+
+def test_tag_parser():
+    tag_parser = acrawler.TagParser({"a"})
+    assert list(tag_parser.consume(example_html)) == [
+        acrawler.Tag("a", {"href": "https://www.iana.org/domains/example"})]
+
+
+# Requires internet connectivity to test
 @pytest.mark.asyncio
 async def test_run_acrawler(capsys):
     await acrawler.crawl("https://example.com")
     captured = capsys.readouterr()
-    assert captured.out == "Crawling https://example.com...\nDone.\n"
+    assert captured.out == """\
+- !Tag
+  name: a
+  attrs:
+    href: https://www.iana.org/domains/example
+"""
 


### PR DESCRIPTION
1. Use aiohttp client to fetch pages
2. Wrap stdlib html.parser.HTMLParser to parse pages
3. Change crawl function to fetch and parse a page, not just sleep, and output a
   very basic sitemap based on YAML serialization