### PR TITLE
Introduces the start of async unit testing

### DIFF
--- a/acrawler.py
+++ b/acrawler.py
@@ -1,6 +1,9 @@
+import argparse
 import asyncio
 import collections
+import math
 import sys
+import urllib
 from dataclasses import dataclass
 from html.parser import HTMLParser
 
@@ -24,6 +27,7 @@ class CollectorHTMLParser(HTMLParser):
 class Tag:
     name: str
     attrs: dict
+    url: str
     
 
 class TagParser:
@@ -42,7 +46,7 @@ class TagParser:
         self.html_parser.feed(chunk)
         while self.queue:
             tag, attrs = self.queue.popleft()
-            yield Tag(tag, dict(attrs))
+            yield Tag(tag, None, dict(attrs))
 
 
 async def fetch(session, url, chunk_size=8192):
@@ -53,27 +57,164 @@ async def fetch(session, url, chunk_size=8192):
             if not chunk:
                 break
             else:
-                # HTMLParser wants str, not bytes, so coerce accordingly,
-                # assuming UTF-8
-                # FIXME: doublecheck text encoding support
-                yield str(chunk)
+                # HTMLParser wants str, not bytes, so coerce accordingly.
+                yield chunk.decode("utf-8")  # default encoding for aiohttp client
 
 
-async def crawl(site_url):
-    """Given `site_url`, just crawls that page and writes to stdout a sitemap"""
+def resolve_url(root, url):
+    """Return  url` rewritten to use absolute scheme/netloc from root.
+    
+    Fragments are discarded, but queries are retained.
 
-    tag_parser = TagParser({"a", "img"})
+    A single trailing slash is equivalent to an empty path; otherwise it is
+    treated as distinct; see https://searchfacts.com/url-trailing-slash/
+    
+    NOTE that we need to separately consider redirects (301), including with
+    respect to http/https schemes and trailing slash.
+    """
+    parsed_root = urllib.parse.urlsplit(root)
+    parsed = urllib.parse.urlsplit(url)
+    return urllib.parse.urlunsplit((
+        parsed.scheme if parsed.scheme else parsed_root.scheme,
+        parsed.netloc if parsed.netloc else parsed_root.netloc,
+        parsed.path if parsed.path != "/" else "",
+        parsed.query,
+        ""
+    ))
+
+
+class Crawler:
+    # FIXME add doc string
+
+    def __init__(self, session_maker, serializer, root_urls, max_pages=5, num_workers=3):
+        # TODO we should also have some way of configuring seen/frontier
+        self.session_maker = session_maker
+        self.serializer = serializer
+        self.root_urls = root_urls
+        self.sites = set()
+        self.max_pages = max_pages
+        self.num_workers = num_workers
+
+        self.frontier = asyncio.Queue()
+        self.count_pages = 0
+        self.seen = set()
+
+        for url in root_urls:
+            parsed_url = urllib.parse.urlsplit(url)
+            self.sites.add(parsed_url.netloc)
+            self.frontier.put_nowait(url)
+
+    async def crawl(self):
+        """Create and run worker tasks to process the `frontier` concurrently"""
+        
+        # This method's implementation is modestly modified from the boilerplate
+        # in https://docs.python.org/3/library/asyncio-queue.html#examples
+        
+        tasks = []
+        for i in range(self.num_workers):
+            task = asyncio.create_task(self.worker(f'worker-{i}'))
+            tasks.append(task)
+
+        # Wait until the frontier queue is fully processed.
+        await self.frontier.join()
+        
+        # Cancel our worker tasks.
+        for task in tasks:
+            task.cancel()
+        
+        # Wait until all worker tasks are cancelled.
+        await asyncio.gather(*tasks, return_exceptions=True)
+
+    async def worker(self, name):
+        # TODO: when crawling APIs/password protected sites, this should be done
+        # per site - presumably this can be memoized
+        async with self.session_maker() as session:
+            while self.count_pages < self.max_pages:
+                # TODO: support other policies in addition to breadth-first
+                # traversal of the frontier
+                url = await self.frontier.get()
+                async for tag in self.crawl_next(session, url):
+                    self.serializer([tag])
+                self.frontier.task_done()
+                self.count_pages += 1
+        
+        # Drain the frontier - do not want to cause a DOS attack
+        while True:
+            url = await self.frontier.get()
+            self.frontier.task_done()
+
+    async def crawl_next(self, session, url):
+        """Crawls the next url from the `frontier`, processing tags for the sitemap"""
+        if url in self.seen:
+            return
+        self.seen.add(url)
+
+        tag_parser = TagParser({"a", "img"})
+
+        # TODO: support 301, error handling in general here
+        async for chunk in fetch(session, url):
+            for tag in self.process_sitemap_tags(url, tag_parser, chunk):
+                yield tag
+
+    def process_sitemap_tags(self, url, tag_parser, chunk):
+        """Yields sitemap tags augmented with `url` and adds to `frontier` if under roots"""
+        for tag in tag_parser.consume(chunk):
+            if tag.name == "a" and "href" in tag.attrs:
+                tag.url = resolve_url(url, tag.attrs["href"])
+                # TODO: repeat of the above parsing work, but of course
+                # minor amount of work
+                parsed_tag_url = urllib.parse.urlsplit(tag.url)
+
+                # Filter entries placed on the exploration frontier such
+                # that they are all prefixed by one of the root sites
+                if parsed_tag_url.netloc in self.sites:
+                    self.frontier.put_nowait(tag.url)
+            elif tag.name == "img" and "src" in tag.attrs:
+                tag.url = resolve_url(url, tag.attrs["src"])
+
+            if tag.url is not None:
+                # If it has a url defined, it is part of the sitemap, so yield
+                yield tag
+
+
+def parse_args(argv):
+    """FIXME"""
+    parser = argparse.ArgumentParser(
+        description="Output sitemap by crawling specified root URLs.")
+    parser.add_argument("roots", metavar="URL", nargs="+",
+        help="List of URL roots to crawl")
+    parser.add_argument("--num-workers", type=int, default=3,
+        help="Number of workers to concurrently crawl pages")
+    parser.add_argument("--max-pages", type=int, default=25,
+        help="Maximum number of pages to crawl")
+    parser.add_argument("--all", action="store_true",
+        help="Retrieve all pages under the specified roots")
+    # TODO: add other output location than sys.stdout
+    return parser.parse_args(argv)
+
+
+async def main(argv):
+    """FIXME"""
+    args = parse_args(argv)
+    if args.all:
+        max_pages = math.inf
+    else:
+        max_pages = args.max_pages
+
     yaml = YAML()
-    yaml.register_class(Tag)  # TODO: consider nondefault serialization
-    async with aiohttp.ClientSession() as session:
-        async for chunk in fetch(session, site_url):
-            for tag in tag_parser.consume(chunk):
-                if tag.name == "a":
-                    # NOTE: outputing a list takes advantage of YAML's
-                    # serialization for lists, which is both concatable and
-                    # tailable
-                    yaml.dump([tag], sys.stdout)
+    yaml.register_class(Tag)
+
+    def serializer(objs):
+        # NOTE: outputing a list takes advantage of YAML's
+        # serialization for lists, which is both concatable and
+        # tailable
+        yaml.dump(objs, sys.stdout)
+
+    crawler = Crawler(
+        aiohttp.ClientSession, serializer,
+        args.roots, max_pages, args.num_workers)
+    await crawler.crawl()
                 
 
 if __name__ == "__main__":  # pragma: no cover
-    asyncio.run(crawl(sys.argv[1]))
+    asyncio.run(main(sys.argv[1:]))

--- a/acrawler.py
+++ b/acrawler.py
@@ -84,8 +84,8 @@ def resolve_url(root, url):
 
 
 class Crawler:
-    # FIXME add doc string
-
+    """Crawls URLs using async tasks and an in-memory frontier queue"""
+    
     def __init__(self, session_maker, serializer, root_urls, max_pages=5, num_workers=3):
         # TODO we should also have some way of configuring seen/frontier
         self.session_maker = session_maker
@@ -157,7 +157,10 @@ class Crawler:
                 yield tag
 
     def process_sitemap_tags(self, url, tag_parser, chunk):
-        """Yields sitemap tags augmented with `url` and adds to `frontier` if under roots"""
+        """Yields sitemap tags and added to `frontier` if under `roots`"""
+        # TODO: This method should be refactored to support a separate factory,
+        # much like session_maker and serializer. This work will require
+        # revisiting tag_parser/chunk calling convention from crawl_next.
         for tag in tag_parser.consume(chunk):
             if tag.name == "a" and "href" in tag.attrs:
                 tag.url = resolve_url(url, tag.attrs["href"])
@@ -178,7 +181,7 @@ class Crawler:
 
 
 def parse_args(argv):
-    """FIXME"""
+    """Parse command line arguments and return an argparse `Namespace`"""
     parser = argparse.ArgumentParser(
         description="Output sitemap by crawling specified root URLs.")
     parser.add_argument("roots", metavar="URL", nargs="+",
@@ -189,7 +192,9 @@ def parse_args(argv):
         help="Maximum number of pages to crawl")
     parser.add_argument("--all", action="store_true",
         help="Retrieve all pages under the specified roots")
-    # TODO: add other output location than sys.stdout
+    parser.add_argument("--out", type=argparse.FileType('w'),
+        default=sys.stdout,
+        help="Output file, defaults to stdout")
 
     args = parser.parse_args(argv)
     if args.all:

--- a/acrawler.py
+++ b/acrawler.py
@@ -26,8 +26,8 @@ class CollectorHTMLParser(HTMLParser):
 @dataclass
 class Tag:
     name: str
-    attrs: dict
     url: str
+    attrs: dict
     
 
 class TagParser:
@@ -190,17 +190,16 @@ def parse_args(argv):
     parser.add_argument("--all", action="store_true",
         help="Retrieve all pages under the specified roots")
     # TODO: add other output location than sys.stdout
-    return parser.parse_args(argv)
+
+    args = parser.parse_args(argv)
+    if args.all:
+        args.max_pages = math.inf
+    return args
 
 
 async def main(argv):
-    """FIXME"""
+    """Runs a crawler under an event loop"""
     args = parse_args(argv)
-    if args.all:
-        max_pages = math.inf
-    else:
-        max_pages = args.max_pages
-
     yaml = YAML()
     yaml.register_class(Tag)
 
@@ -212,7 +211,7 @@ async def main(argv):
 
     crawler = Crawler(
         aiohttp.ClientSession, serializer,
-        args.roots, max_pages, args.num_workers)
+        args.roots, args.max_pages, args.num_workers)
     await crawler.crawl()
                 
 

--- a/test_acrawler.py
+++ b/test_acrawler.py
@@ -1,5 +1,14 @@
-import pytest
+import asyncio
+import collections
+import contextlib
+import functools
+import unittest
+import unittest.mock
+
 import acrawler
+import pytest
+from acrawler import Tag
+from ruamel.yaml import YAML
 
 
 # Based on the page from https://example.com
@@ -19,16 +28,139 @@ example_html = """
 """
 
 
+def make_fake_http_session(data):
+    # The aiohttp client is a bit complex, so creating a fake is likewise complex!
+
+    class FakeContent:
+        def __init__(self, num_chunks=13):
+            chunk_length = len(data) // num_chunks
+            self.chunks = collections.deque()
+            for i in range(num_chunks - 1):
+                self.chunks.append(
+                    data[(i * chunk_length):((i + 1) * chunk_length)])
+            self.chunks.append(data[((num_chunks - 1) * chunk_length):])
+
+        def read(self, chunk_size):
+            fake_result = asyncio.Future()
+            try:
+                chunk = self.chunks.popleft()
+                fake_result.set_result(chunk)
+            except IndexError:
+                fake_result.set_result(None)
+            return fake_result
+
+    class FakeResponse:
+        def __init__(self):
+            self.content = FakeContent()
+
+    class FakeAsyncContextManager:
+        def __init__(self):
+            self.response = FakeResponse()
+
+        def __aenter__(self):
+            fake_response = asyncio.Future()
+            fake_response.set_result(self.response)
+            return fake_response
+
+        def __aexit__(self, exc_type, exc, tb):
+            fake_exit = asyncio.Future()
+            fake_exit.set_result(None)
+            return fake_exit
+
+    class FakeSession:
+        def get(self, url):
+            return FakeAsyncContextManager()
+
+        def __aenter__(self):
+            fake_response = asyncio.Future()
+            fake_response.set_result(self)
+            return fake_response
+
+        def __aexit__(self, exc_type, exc, tb):
+            fake_exit = asyncio.Future()
+            fake_exit.set_result(None)
+            return fake_exit
+
+    return FakeSession()
+
+
 def test_tag_parser():
     tag_parser = acrawler.TagParser({"a"})
     assert list(tag_parser.consume(example_html)) == [
-        acrawler.Tag("a", {"href": "https://www.iana.org/domains/example"})]
+        acrawler.Tag(
+            "a", None, {"href": "https://www.iana.org/domains/example"})]
+
+
+@pytest.mark.asyncio
+async def test_fetch():
+    chunks = []
+    async for chunk in acrawler.fetch(
+        make_fake_http_session(
+            bytes(example_html, "utf-8")), "https://url-is.invalid"):
+        chunks.append(chunk)
+    assert "".join(chunks) == example_html
+
+
+# @pytest.mark.asyncio
+# async def test_crawler():
+#     fake_session_maker = functools.partial(
+#         make_fake_http_session, bytes(example_html, "utf-8"))
+
+#     tags = []
+#     def serializer(objects):
+#         tags.append(objects)
+
+#     crawler = acrawler.Crawler(
+#         fake_session_maker, serializer,
+#         ["https://url-is.invalid", "https://another-url-is.invalid"],
+#         num_workers=1, max_pages=1)
+#     await crawler.crawl()
+#     assert tags == [[Tag(
+#         "a", "https://www.iana.org/domains/example",
+#         {"href": "https://www.iana.org/domains/example"})]]
+#     assert crawler.frontier.qsize() == 0
+#     assert len(crawler.seen) == 1
+
+
+def test_parse_command_line_some_pages():
+    args = acrawler.parse_args(
+        "--max-pages=42 "
+        "https://example.com https://example.org https://example.net".split())
+    assert args.roots == [
+        "https://example.com",
+        "https://example.org",
+        "https://example.net",
+    ]
+    assert args.max_pages == 42
+    assert not args.all
+
+
+def test_parse_command_line_all_pages():
+    args = acrawler.parse_args(
+        "--all https://example.com".split())
+    assert args.roots == ["https://example.com"]
+    assert args.max_pages == 25  # Default, but ignore given --all
+    assert args.all
+
+
+def test_resolve_url():
+    assert acrawler.resolve_url(
+        "https://example.com", "https://www.iana.org/domains/example") == \
+        "https://www.iana.org/domains/example"
+    assert acrawler.resolve_url("https://example.com", "baz/bar") == \
+        "https://example.com/baz/bar"
+    assert acrawler.resolve_url("https://example.com",
+        "https://example.com/") == \
+        "https://example.com"
+    assert acrawler.resolve_url("https://example.com",
+        "https://example.com#fragment") == \
+        "https://example.com"
 
 
 # Requires internet connectivity to test
 @pytest.mark.asyncio
 async def test_run_acrawler(capsys):
-    await acrawler.crawl("https://example.com")
+    await acrawler.main("https://example.com")
     captured = capsys.readouterr()
     assert captured.out == """\
 - !Tag
@@ -36,4 +168,10 @@ async def test_run_acrawler(capsys):
   attrs:
     href: https://www.iana.org/domains/example
 """
-
+    
+    yaml = YAML()
+    yaml.register_class(Tag)
+    sitemap = yaml.load(captured.out)
+    assert sitemap == [
+        Tag("a", "https://www.iana.org/domains/example",
+            {"href": "https://www.iana.org/domains/example"})]


### PR DESCRIPTION
This PR starts building out a robust approach to async unit testing based on resolved futures, including in the usage of mocking out relatively complex async context managers. A later iteration will look at adding tests with errored futures.

Also fixes inadvertent DOS line endings that were introduced - sorry diff.